### PR TITLE
chore: exclude cli publishing for now

### DIFF
--- a/apps/ogre-cli/package.json
+++ b/apps/ogre-cli/package.json
@@ -6,6 +6,7 @@
 	"bin": "dist/cli.js",
 	"type": "module",
 	"main": "dist/cli.js",
+	"private": true,
 	"engines": {
 		"node": ">=18"
 	},


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @dotinc/ogre@0.3.1-canary.145.7942729114.0
  npm install @dotinc/ogre-react@0.3.1-canary.145.7942729114.0
  # or 
  yarn add @dotinc/ogre@0.3.1-canary.145.7942729114.0
  yarn add @dotinc/ogre-react@0.3.1-canary.145.7942729114.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
