### PR TITLE
feat: allow access to remote state

### DIFF
--- a/packages/ogre/src/commit.test.ts
+++ b/packages/ogre/src/commit.test.ts
@@ -2,12 +2,13 @@ import { test } from "tap";
 
 import {
   addOneStep,
+  ComplexObject,
   getBaseline,
   sumChanges,
   testAuthor,
   updateHeaderData,
 } from "./test.utils";
-import { printChangeLog } from "./repository";
+import { printChangeLog, Repository } from "./repository";
 
 test("baseline with 1 commit and zero changelog entries", async (t) => {
   const [repo] = await getBaseline();
@@ -21,6 +22,21 @@ test("head points to main", async (t) => {
   const [repo] = await getBaseline();
 
   t.equal(repo.head(), "refs/heads/main", "head not pointing where it should");
+});
+
+test("changes are available for commit if starting from empty", async (t) => {
+  const repo = new Repository<ComplexObject>({}, {});
+  repo.data.name = "some data";
+
+  const dirty = repo.status();
+
+  t.equal(
+    dirty.length,
+    1,
+    "Status does not contain the right amount of changes",
+  );
+  await repo.commit("baseline", testAuthor);
+  t.pass();
 });
 
 test("no commit without changes", async (t) => {

--- a/packages/ogre/src/commit.ts
+++ b/packages/ogre/src/commit.ts
@@ -2,13 +2,13 @@ import { digest } from "./hash";
 import { Operation } from "fast-json-patch";
 
 export interface Commit {
-  // The hash of the commit
-  // Is an sha256 of:
-  // - tree object reference (changes?)
-  // - parent object reference (parent hash)
-  // - author
-  // - author commit timestamp with timezone
-  // - commit message
+  /*The hash of the commit. Is an sha256 of:
+          - tree object reference (changes?)
+          - parent object reference (parent hash)
+          - author
+          - author commit timestamp with timezone
+          - commit message
+        */
   hash: string;
   tree: string;
 


### PR DESCRIPTION
### TL;DR
This pull request introduces changes and enhancements in the Repository class in 'repository.ts' and corresponding tests in 'commit.test.ts'. It also includes updates to the interface description in 'commit.ts'.

### What changed?
The Repository class now has a new member 'remoteRefs' and a respective accessor function 'remote'. The member keeps track of the state of the remote during initialization. The new test checks for the status and commit operations on a Repository instance.

In 'commit.ts', block comments format has been introduced in place of line comments for commit hash details.

### How to test?
Reviewers can run the included test in 'commit.test.ts' to verify the new changes functionality. Check updated commenting style in 'commit.ts'.

### Why make this change?
The changes enhance the functionality of the Repository class and improve code readability in 'commit.ts' with proper block comments.

---

