### PR TITLE
fix: remove history generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@ keep the history around for a bit longer. The library uses json-patch RFC6902 fo
 - Diff
 - Status
 - Apply
-  > ⚠️ Setting a value for an undefined prop `{prop: undefined}` will result in the `compare` call as a `replace`
-  operation, but will be recorded by the observer as
-  an `add` operation. See https://github.com/Starcounter-Jack/JSON-Patch/issues/280 for details
+  > ⚠️ Currently with a workaround to adapt for setting a value for an undefined prop `{prop: undefined}` will result in
+  the `compare` call as a `replace`
+  operation, but will be recorded by the observer as an `add` operation.
+  > Applying a patch like that will result in internal retry with `add` instead of `replace`.
+  >
+  > See https://github.com/Starcounter-Jack/JSON-Patch/issues/280 for details
 - Visualization via `@dotinc/ogre-react`
 - Merge
     - fast-forward

--- a/packages/ogre/src/git2json.ts
+++ b/packages/ogre/src/git2json.ts
@@ -31,7 +31,7 @@ const findRefs = (commit: Commit, refs: Map<string, Reference>) => {
  * in the Repository history. The json representation is returned in `git2json` format based on:
  * https://github.com/fabien0102/git2json/blob/e067166d2468018b6f3982a8fb44a2e54110ce02/src/git2json.js#L5-L22
  */
-export const formatGit2Json = <T = any>(history: History<T>) => {
+export const formatGit2Json = <T = any>(history: History) => {
   const { commits, refs } = history;
   return commits.reverse().map((c) => {
     const [name, email] = cleanAuthor(c.author);


### PR DESCRIPTION
### TL;DR

This pull request updates the handling of undefined properties during the compare call.

### What changed?

The README documentation and the `formatGit2Json` function in `git2json.ts` have been updated. The `formatGit2Json` function no longer accepts a generic parameter.

### How to test?

Ensure the library behaves as expected when dealing with undefined properties during the compare call. Unit tests should confirm this behavior.

### Why make this change?

There was an inconsistency in how undefined properties were handled during the compare call as documented in the README. This update makes the operation clearer and resolves potential issues.

---


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @dotinc/ogre@0.6.1-canary.159.8401791568.0
  npm install @dotinc/ogre-react@0.6.1-canary.159.8401791568.0
  # or 
  yarn add @dotinc/ogre@0.6.1-canary.159.8401791568.0
  yarn add @dotinc/ogre-react@0.6.1-canary.159.8401791568.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
