### PR TITLE
fix: mutable remote refs

### DIFF
--- a/packages/ogre/src/repository.ts
+++ b/packages/ogre/src/repository.ts
@@ -21,7 +21,7 @@ import {
   createHeadRefValue,
   getLastRefPathElement,
   headValueRefPrefix,
-  immutableRefCopy,
+  immutableMapCopy,
   localHeadPathPrefix,
   mapPath,
   mutableMapCopy,
@@ -109,7 +109,7 @@ export class Repository<T extends { [k: PropertyKey]: any }>
   constructor(obj: Partial<T>, options: RepositoryOptions<T>) {
     // FIXME: move this to refs/remote as git would do?
 
-    this.remoteRefs = immutableRefCopy(options.history?.refs);
+    this.remoteRefs = immutableMapCopy(options.history?.refs);
     this.original = deepClone(obj);
     // store js ref, so obj can still be modified without going through repo.data
     this.data = obj as T;

--- a/packages/ogre/src/repository.ts
+++ b/packages/ogre/src/repository.ts
@@ -21,8 +21,10 @@ import {
   createHeadRefValue,
   getLastRefPathElement,
   headValueRefPrefix,
+  immutableRefCopy,
   localHeadPathPrefix,
   mapPath,
+  mutableMapCopy,
   REFS_HEAD_KEY,
   REFS_MAIN_KEY,
   refsAtCommit,
@@ -92,9 +94,10 @@ export interface RepositoryObject<T extends { [k: string]: any }> {
   reset(mode?: "soft" | "hard", shaish?: string): void;
 
   /**
-   * Returns the remote references from the initialization of the repository
+   * Returns the remote references from the initialization of the repository.
+   * The returned map is a readonly of remote.
    */
-  remote(): Map<string, Reference> | undefined;
+  remote(): ReadonlyMap<string, Readonly<Reference>> | undefined;
 }
 
 /**
@@ -105,22 +108,23 @@ export class Repository<T extends { [k: PropertyKey]: any }>
 {
   constructor(obj: Partial<T>, options: RepositoryOptions<T>) {
     // FIXME: move this to refs/remote as git would do?
-    this.remoteRefs = options.history?.refs;
+
+    this.remoteRefs = immutableRefCopy(options.history?.refs);
     this.original = deepClone(obj);
     // store js ref, so obj can still be modified without going through repo.data
     this.data = obj as T;
     this.observer = observe(obj as T);
-    this.refs =
-      options.history?.refs ??
-      new Map<string, Reference>([
-        [
-          REFS_HEAD_KEY,
-          {
-            name: REFS_HEAD_KEY,
-            value: `ref: ${REFS_MAIN_KEY}`,
-          },
-        ],
-      ]);
+    this.refs = options.history?.refs
+      ? mutableMapCopy(options.history?.refs)
+      : new Map<string, Reference>([
+          [
+            REFS_HEAD_KEY,
+            {
+              name: REFS_HEAD_KEY,
+              value: `ref: ${REFS_MAIN_KEY}`,
+            },
+          ],
+        ]);
 
     this.commits = options.history?.commits ?? [];
 
@@ -138,14 +142,16 @@ export class Repository<T extends { [k: PropertyKey]: any }>
   data: T;
 
   // stores the remote state upon initialization
-  private readonly remoteRefs: Map<string, Reference> | undefined;
+  private readonly remoteRefs:
+    | ReadonlyMap<string, Readonly<Reference>>
+    | undefined;
 
   private observer: Observer<T>;
 
   private readonly refs: Map<string, Reference>;
   private readonly commits: Commit[];
 
-  remote(): Map<string, Reference> | undefined {
+  remote(): ReadonlyMap<string, Readonly<Reference>> | undefined {
     return this.remoteRefs;
   }
 

--- a/packages/ogre/src/utils.ts
+++ b/packages/ogre/src/utils.ts
@@ -218,7 +218,7 @@ export const printChange = (chg: Operation) => {
 export const getLastRefPathElement = (thePath: string) =>
   thePath.substring(thePath.lastIndexOf("/") + 1);
 
-export const immutableRefCopy = <T extends object>(
+export const immutableMapCopy = <T extends object>(
   map: Map<string, T> | undefined,
 ) => {
   if (!map) {

--- a/packages/ogre/src/utils.ts
+++ b/packages/ogre/src/utils.ts
@@ -217,3 +217,24 @@ export const printChange = (chg: Operation) => {
  */
 export const getLastRefPathElement = (thePath: string) =>
   thePath.substring(thePath.lastIndexOf("/") + 1);
+
+export const immutableRefCopy = <T extends object>(
+  map: Map<string, T> | undefined,
+) => {
+  if (!map) {
+    return undefined;
+  }
+  const m = new Map<string, Readonly<T>>();
+  for (const [key, value] of map) {
+    m.set(key, { ...value });
+  }
+  return m as ReadonlyMap<string, Readonly<T>>;
+};
+
+export const mutableMapCopy = <T extends object>(map: Map<string, T>) => {
+  const m = new Map<string, T>();
+  for (const [key, value] of map) {
+    m.set(key, { ...value });
+  }
+  return m;
+};


### PR DESCRIPTION
### TL;DR
Fix a bug in restoring from history in the Ogre repository.

### What changed?
Added a test for restoring from history and a test for remoteRefs not changing on commit. Also added utility functions immutableMapCopy and mutableMapCopy.

### How to test?
Run the new tests added and verify the correct behavior.

### Why make this change?
Since maps store objects by reference, remoteRefs were mutated during commits so they became unusable.

---

https://macarthur.me/posts/maps-store-objects-by-reference/

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @dotinc/ogre@0.8.1-canary.171.8559806794.0
  npm install @dotinc/ogre-react@0.8.1-canary.171.8559806794.0
  # or 
  yarn add @dotinc/ogre@0.8.1-canary.171.8559806794.0
  yarn add @dotinc/ogre-react@0.8.1-canary.171.8559806794.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
