### PR TITLE
feat: git cherry

### DIFF
--- a/packages/ogre/package.json
+++ b/packages/ogre/package.json
@@ -12,6 +12,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "nyc --reporter=lcov tap --coverage-report=none --allow-incomplete-coverage",
+    "test:cov": "tap",
+    "test:covhtml": "tap --coverage-report=lcov",
     "test:node": "node --import tsx --test src/**/*.test.ts",
     "coverage:html": "nyc report --reporter=html"
   },

--- a/packages/ogre/src/commit.ts
+++ b/packages/ogre/src/commit.ts
@@ -2,13 +2,13 @@ import { digest } from "./hash";
 import { Operation } from "fast-json-patch";
 
 export interface Commit {
-  /*The hash of the commit. Is an sha256 of:
-          - tree object reference (changes?)
-          - parent object reference (parent hash)
-          - author
-          - author commit timestamp with timezone
-          - commit message
-        */
+  /*The hash of the commit. Is a sha256 of:
+                - tree object reference (changes?)
+                - parent object reference (parent hash)
+                - author
+                - author commit timestamp with timezone
+                - commit message
+              */
   hash: string;
   tree: string;
 
@@ -19,7 +19,7 @@ export interface Commit {
   parent: string | undefined;
 
   // The diff of this commit from the parent
-  changes: Operation[];
+  changes: Array<Operation>;
 
   // Commit timestamp with timezone
   timestamp: Date;
@@ -29,7 +29,7 @@ export interface CommitHashContent {
   message: string;
   author: string;
   parentRef: string | undefined;
-  changes: Operation[];
+  changes: Array<Operation>;
   timestamp: Date;
 }
 

--- a/packages/ogre/src/repository.ts
+++ b/packages/ogre/src/repository.ts
@@ -21,6 +21,7 @@ import {
   createHeadRefValue,
   getLastRefPathElement,
   headValueRefPrefix,
+  immutableArrayCopy,
   immutableMapCopy,
   localHeadPathPrefix,
   mapPath,
@@ -98,6 +99,11 @@ export interface RepositoryObject<T extends { [k: string]: any }> {
    * The returned map is a readonly of remote.
    */
   remote(): ReadonlyMap<string, Readonly<Reference>> | undefined;
+
+  /**
+   * Cherry returns the commits that are missing from upstream and the refs that have been moved since remote
+   */
+  cherry(): { commits: Array<Commit>; refs: Map<string, Reference> };
 }
 
 /**
@@ -108,8 +114,11 @@ export class Repository<T extends { [k: PropertyKey]: any }>
 {
   constructor(obj: Partial<T>, options: RepositoryOptions<T>) {
     // FIXME: move this to refs/remote as git would do?
-
     this.remoteRefs = immutableMapCopy(options.history?.refs);
+    this.remoteCommits = immutableArrayCopy<Commit, string>(
+      options.history?.commits,
+      (c) => c.hash,
+    );
     this.original = deepClone(obj);
     // store js ref, so obj can still be modified without going through repo.data
     this.data = obj as T;
@@ -146,10 +155,106 @@ export class Repository<T extends { [k: PropertyKey]: any }>
     | ReadonlyMap<string, Readonly<Reference>>
     | undefined;
 
+  // stores the remote state upon initialization
+  private readonly remoteCommits: ReadonlyArray<Readonly<string>> | undefined;
+
   private observer: Observer<T>;
 
   private readonly refs: Map<string, Reference>;
   private readonly commits: Array<Commit>;
+
+  cherry(): { commits: Array<Commit>; refs: Map<string, Reference> } {
+    const commits: Array<Commit> = [];
+    const refs = new Map<string, Reference>();
+
+    const collectedHashes: Array<string> = [];
+    const shouldExclude = (hash: string) =>
+      this.remoteCommits?.includes(hash) || collectedHashes.includes(hash);
+    const collect = (c: Commit) => {
+      // we can't include remote state in the pending report
+      if (shouldExclude(c.hash)) {
+        return false;
+      }
+      commits.push(c);
+      collectedHashes.push(c.hash);
+      return true;
+    };
+    // collect ref updates and commits that are not present on the remote
+    for (const [key, ref] of this.refs) {
+      if (key === REFS_HEAD_KEY) {
+        continue;
+      }
+      const remote = this.remoteRefs?.get(key);
+      if (!remote) {
+        // if we have no remote pair, we need to sync the ref
+        refs.set(key, ref);
+        const localCommit = this.commits.find((c) => c.hash === ref.value);
+        // if ref is not pointing to a commit move on
+        if (!localCommit) {
+          continue;
+        }
+        // map all commits to root
+        const [isAncestor, path] = mapPath(
+          this.commits,
+          localCommit,
+          undefined,
+        );
+
+        if (isAncestor) {
+          for (let i = 0; i < path.length; i++) {
+            const commit = path[i];
+            collect({
+              hash: commit.hash,
+              author: commit.author,
+              changes: commit.changes,
+              message: commit.message,
+              parent: commit.parent,
+              timestamp: commit.timestamp,
+              tree: commit.tree,
+            });
+          }
+        }
+        continue;
+      }
+
+      if (remote.value === ref.value) {
+        // early exit if remote is the same
+        continue;
+      }
+
+      // local and remote refs differ
+      refs.set(key, ref);
+      const localCommit = this.commits.find((c) => c.hash === ref.value);
+      // if ref is not pointing to a commit move on
+      if (!localCommit) {
+        continue;
+      }
+      // FIXME: do we have to have the remote ref as a commit locally?
+      const remoteCommit = this.commits.find((c) => c.hash === remote.value)!;
+      const [isAncestor, path] = mapPath(
+        this.commits,
+        localCommit,
+        remoteCommit,
+      );
+
+      if (isAncestor) {
+        for (let i = 0; i < path.length; i++) {
+          const commit = path[i];
+          collect({
+            hash: commit.hash,
+            author: commit.author,
+            changes: commit.changes,
+            message: commit.message,
+            parent: commit.parent,
+            timestamp: commit.timestamp,
+            tree: commit.tree,
+          });
+        }
+      }
+    }
+
+    return { commits, refs };
+  }
 
   remote(): ReadonlyMap<string, Readonly<Reference>> | undefined {
     return this.remoteRefs;
@@ -458,7 +563,7 @@ export class Repository<T extends { [k: PropertyKey]: any }>
     // *---*
     //      \
     //       *---*---* (master, foo)
-    const [isAncestor] = mapPath(headCommit, srcCommit, this.commits);
+    const [isAncestor] = mapPath(this.commits, srcCommit, headCommit);
     if (isAncestor) {
       this.moveRef(this.head(), srcCommit);
       this.moveTo(srcCommit);

--- a/packages/ogre/src/repository.ts
+++ b/packages/ogre/src/repository.ts
@@ -50,18 +50,18 @@ export interface RepositoryObject<T extends { [k: string]: any }> {
    * @param shaishFrom expression (e.g. refs (branches, tags), commitSha)
    * @param shaishTo expression (e.g. refs (branches, tags), commitSha)
    */
-  diff(shaishFrom: string, shaishTo?: string): Operation[];
+  diff(shaishFrom: string, shaishTo?: string): Array<Operation>;
 
   /**
    * Returns pending changes.
    */
-  status(): Operation[];
+  status(): Array<Operation>;
 
   /**
    * Applies a patch to the repository's HEAD
    * @param patch
    */
-  apply(patch: Operation[]): void;
+  apply(patch: Array<Operation>): void;
 
   // It returns the reference where we are currently at
   head(): string;
@@ -73,7 +73,7 @@ export interface RepositoryObject<T extends { [k: string]: any }> {
 
   checkout(shaish: string, createBranch?: boolean): void;
 
-  logs(commits?: number): Commit[];
+  logs(commits?: number): Array<Commit>;
 
   createBranch(name: string): string;
 
@@ -149,7 +149,7 @@ export class Repository<T extends { [k: PropertyKey]: any }>
   private observer: Observer<T>;
 
   private readonly refs: Map<string, Reference>;
-  private readonly commits: Commit[];
+  private readonly commits: Array<Commit>;
 
   remote(): ReadonlyMap<string, Readonly<Reference>> | undefined {
     return this.remoteRefs;
@@ -166,8 +166,8 @@ export class Repository<T extends { [k: PropertyKey]: any }>
     this.observer = observe(this.data);
   }
 
-  apply(patch: Operation[]): JsonPatchError | undefined {
-    const p = deepClone(patch) as Operation[];
+  apply(patch: Array<Operation>): JsonPatchError | undefined {
+    const p = deepClone(patch) as Array<Operation>;
     const err = validate(p, this.data);
     if (err) {
       // credit goes to @NicBright
@@ -247,7 +247,7 @@ export class Repository<T extends { [k: PropertyKey]: any }>
     return this.diff(commit.hash);
   }
 
-  diff(shaishFrom: string, shaishTo?: string): Operation[] {
+  diff(shaishFrom: string, shaishTo?: string): Array<Operation> {
     const [cFrom] = shaishToCommit(shaishFrom, this.refs, this.commits);
     let target: T;
     if (shaishTo) {
@@ -393,7 +393,7 @@ export class Repository<T extends { [k: PropertyKey]: any }>
     }
     // traverse backwards and build commit tree
     let c: Commit | undefined = commit;
-    let commitsList: Commit[] = [];
+    let commitsList: Array<Commit> = [];
     while (c !== undefined) {
       commitsList = [c, ...commitsList];
       c = this.commits.find((parent) => parent.hash === c?.parent);
@@ -408,8 +408,8 @@ export class Repository<T extends { [k: PropertyKey]: any }>
     };
   }
 
-  logs(numberOfCommits?: number): Commit[] {
-    const logs: Commit[] = [];
+  logs(numberOfCommits?: number): Array<Commit> {
+    const logs: Array<Commit> = [];
     const limit = numberOfCommits ?? -1;
     let c = this.commitAtHead();
     let counter = 0;

--- a/packages/ogre/src/utils.test.ts
+++ b/packages/ogre/src/utils.test.ts
@@ -1,5 +1,7 @@
 import { test } from "tap";
-import { cleanAuthor } from "./utils";
+import { cleanAuthor, mapPath, shaishToCommit } from "./utils";
+import { Repository } from "./repository";
+import { ComplexObject, testAuthor } from "./test.utils";
 
 test("author <email@domain.info>", (t) => {
   const [name, email] = cleanAuthor("author <email@domain.info>");
@@ -51,4 +53,89 @@ test("empty author", (t) => {
     { message: "author not provided" },
   );
   t.end();
+});
+
+test("mapPath", async (t) => {
+  t.test("find root", async (t) => {
+    const repo = new Repository<ComplexObject>({}, {});
+    repo.data.name = "name";
+    const hash = await repo.commit("set name", testAuthor);
+
+    const { commits, refs } = repo.getHistory();
+    const [c] = shaishToCommit(hash, refs, commits);
+    const [isAncestor, path] = mapPath(commits, c);
+    t.equal(path.length, 1, "path does not contain 1 commit");
+    t.equal(isAncestor, true, "root is not ancestor of commit");
+    t.matchOnlyStrict(path[0], c, "path does not contain the right commit");
+  });
+
+  t.test("finds full path to root", async (t) => {
+    const repo = new Repository<ComplexObject>({}, {});
+    repo.data.name = "name";
+    const h1 = await repo.commit("set name", testAuthor);
+    repo.data.description = "description";
+    const h2 = await repo.commit("set desc", testAuthor);
+
+    const { commits, refs } = repo.getHistory();
+    const [c1] = shaishToCommit(h1, refs, commits);
+    const [c2] = shaishToCommit(h2, refs, commits);
+    const [isAncestor, path] = mapPath(commits, c2);
+
+    t.equal(path.length, 2, "path does not contain 1 commit");
+    t.equal(isAncestor, true, "root is not ancestor of commit");
+    t.matchOnlyStrict(
+      path[0],
+      c2,
+      "path does not contain the right commit at 0",
+    );
+    t.matchOnlyStrict(
+      path[1],
+      c1,
+      "path does not contain the right commit at 1",
+    );
+  });
+
+  t.test("parent-to-child no ancestor", async (t) => {
+    const repo = new Repository<ComplexObject>({}, {});
+    repo.data.name = "name";
+    const h1 = await repo.commit("set name", testAuthor);
+    repo.data.description = "description";
+    const h2 = await repo.commit("set desc", testAuthor);
+
+    const { commits, refs } = repo.getHistory();
+    const [c1] = shaishToCommit(h1, refs, commits);
+    const [c2] = shaishToCommit(h2, refs, commits);
+    const [isAncestor, path] = mapPath(commits, c1, c2);
+
+    t.equal(path.length, 0, "path contains a commit");
+    t.equal(isAncestor, false, "child must not be an ancestor of parent");
+  });
+
+  t.test("finds path across 2 branches", async (t) => {
+    const repo = new Repository<ComplexObject>({}, {});
+    repo.data.name = "name";
+    const h1 = await repo.commit("set name", testAuthor);
+    repo.checkout("branch", true);
+
+    repo.data.description = "description";
+    const h2 = await repo.commit("set desc", testAuthor);
+
+    const { commits, refs } = repo.getHistory();
+    const [c1] = shaishToCommit(h1, refs, commits);
+    const [c2] = shaishToCommit(h2, refs, commits);
+    const [isAncestor, path] = mapPath(commits, c2);
+
+    t.equal(path.length, 2, "path does not contain 1 commit");
+    t.equal(isAncestor, true, "root is not ancestor of commit");
+    t.matchOnlyStrict(
+      path[0],
+      c2,
+      "path does not contain the right commit at 0",
+    );
+    t.matchOnlyStrict(
+      path[1],
+      c1,
+      "path does not contain the right commit at 1",
+    );
+  });
 });


### PR DESCRIPTION
refactor: array type syntax

feat: cherry for pending changes

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @dotinc/ogre@0.9.0-canary.172.8583416340.0
  npm install @dotinc/ogre-react@0.9.0-canary.172.8583416340.0
  # or 
  yarn add @dotinc/ogre@0.9.0-canary.172.8583416340.0
  yarn add @dotinc/ogre-react@0.9.0-canary.172.8583416340.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
