### PR TITLE
feat: allow override for gitgraphjs options

### DIFF
--- a/.swm/feat-allow-override-for-gitgraphjs-options.eh06czwq.sw.md
+++ b/.swm/feat-allow-override-for-gitgraphjs-options.eh06czwq.sw.md
@@ -1,0 +1,90 @@
+---
+title: 'feat: allow override for gitgraphjs options'
+---
+📦 Published PR as canary version:  ✨ Test out this PR locally via:
+
+```bash
+npm install @dotinc/ogre@0.10.0-canary.173.8587606058.0
+npm install @dotinc/ogre-react@0.10.0-canary.173.8587606058.0
+# or 
+yarn add @dotinc/ogre@0.10.0-canary.173.8587606058.0
+yarn add @dotinc/ogre-react@0.10.0-canary.173.8587606058.0
+```
+
+<SwmSnippet path="/packages/ogre-react/OgreGraph.tsx" line="12">
+
+---
+
+Include partial options from <SwmToken path="/packages/ogre-react/OgreGraph.tsx" pos="19:2:2" line-data="interface GitgraphOptions {">`GitgraphOptions`</SwmToken> and re-export template creation functions.
+
+This extension includes an option for the graph to override commit level options as well by providing a map of <SwmToken path="/packages/ogre-react/OgreGraph.tsx" pos="34:1:1" line-data="  commitOptions?: Map&lt;string, CommitOptions&gt;;">`commitOptions`</SwmToken>
+
+```tsx
+
+export {
+  templateExtend,
+  metroTemplate,
+  blackArrowTemplate,
+} from "@gitgraph/core/lib/template";
+
+interface GitgraphOptions {
+  template?: TemplateName | Template;
+  orientation?: Orientation;
+  reverseArrow?: boolean;
+  initCommitOffsetX?: number;
+  initCommitOffsetY?: number;
+  mode?: Mode;
+  author?: string;
+  branchLabelOnEveryCommit?: boolean;
+  commitMessage?: string;
+}
+```
+
+---
+
+</SwmSnippet>
+
+<SwmSnippet path="/packages/ogre-react/OgreGraph.tsx" line="43">
+
+---
+
+This is where the <SwmToken path="/packages/ogre-react/OgreGraph.tsx" pos="34:1:1" line-data="  commitOptions?: Map&lt;string, CommitOptions&gt;;">`commitOptions`</SwmToken> are applied to the repository commits.
+
+```tsx
+
+  useEffect(() => {
+    if (!graphData) {
+      const history = repository.getHistory();
+      const data = formatGit2Json(history).map((c) => {
+        const opts = commitOptions?.get(c.hash);
+        return {
+          ...c,
+          ...(opts ? opts : {}),
+        };
+      });
+      setGraphData(data);
+    }
+  }, [repository]);
+```
+
+---
+
+</SwmSnippet>
+
+<SwmSnippet path="/packages/ogre-react/OgreGraph.tsx" line="57">
+
+---
+
+Passing down the global options to Gitgraph.
+
+```tsx
+
+  return !graphData ? null : (
+    <Gitgraph options={options}>
+```
+
+---
+
+</SwmSnippet>
+
+<SwmMeta version="3.0.0" repo-id="Z2l0aHViJTNBJTNBb2dyZSUzQSUzQWRvdGluZHVzdHJpZXM="><sup>Powered by [Swimm](https://app.swimm.io/)</sup></SwmMeta>

--- a/.swm/swimm.json
+++ b/.swm/swimm.json
@@ -1,0 +1,3 @@
+{
+    "repo_id": "Z2l0aHViJTNBJTNBb2dyZSUzQSUzQWRvdGluZHVzdHJpZXM="
+}

--- a/apps/ogre-cli/package.json
+++ b/apps/ogre-cli/package.json
@@ -30,7 +30,7 @@
 		"@sindresorhus/tsconfig": "^3.0.1",
 		"@types/color-convert": "^2.0.3",
 		"@types/lodash": "^4.14.202",
-		"@types/node": "^17.0.45",
+		"@types/node": "^20.12.5",
 		"@types/react": "^18.0.32",
 		"@vdemedes/prettier-config": "^2.0.1",
 		"auto-changelog": "^2.4.0",
@@ -41,7 +41,7 @@
 		"eslint-plugin-react-hooks": "^4.6.0",
 		"prettier": "^2.8.7",
 		"ts-node": "^10.9.1",
-		"typescript": "^5.0.3"
+		"typescript": "^5.4.4"
 	},
 	"ava": {
 		"extensions": {

--- a/apps/ogre-demo/package.json
+++ b/apps/ogre-demo/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@dotinc/ogre": "^0.9.0",
-    "@dotinc/ogre-react": "^0.9.0",
+    "@dotinc/ogre": "*",
+    "@dotinc/ogre-react": "*",
     "next": "12.1.0",
     "next-plausible": "^3.12.0",
     "next-transpile-modules": "^9.1.0",
@@ -20,12 +20,12 @@
     "react-live": "3.2.0"
   },
   "devDependencies": {
-    "@types/node": "17.0.45",
+    "@types/node": "^20.12.5",
     "@types/react": "17.0.39",
     "config": "^0.2.0",
     "eslint": "8.56.0",
     "eslint-config-next": "12.3.4",
     "tsconfig": "*",
-    "typescript": "4.7.4"
+    "typescript": "^5.4.4"
   }
 }

--- a/apps/ogre-demo/pages/index.tsx
+++ b/apps/ogre-demo/pages/index.tsx
@@ -79,7 +79,7 @@ const Home: NextPage = () => {
             <LivePreview
               style={{
                 borderRadius: `${polished.rem(0)} ${polished.rem(
-                  5
+                  5,
                 )} ${polished.rem(5)} ${polished.rem(0)}`,
                 position: "relative",
                 padding: "0.5rem",
@@ -120,11 +120,11 @@ const code = `
   const [repository, setRepository] = useState(undefined)
   useEffect(() => {
     if (!repository) {
-      setupRepo()
+      setupRepo().then(r => setRepository(r))
     }
     return () => setRepository(undefined)
   }, [])
-
+  
   const setupRepo = async () => {
     let author = 'author <author@email.info>'
     const r = new Repository({description: '', name: ''}, {})
@@ -147,8 +147,8 @@ const code = `
     r.checkout('main')
     r.merge('description')
 
-    setRepository(r)
+    return r
   }
-
+  
   return repository ? <OgreGraph repository={repository} /> : null
 }`;

--- a/apps/ogre-demo/tsconfig.json
+++ b/apps/ogre-demo/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "tsconfig/nextjs.json",
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -17,6 +21,12 @@
     "incremental": true,
     "downlevelIteration": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@sindresorhus/tsconfig": "^3.0.1",
         "@types/color-convert": "^2.0.3",
         "@types/lodash": "^4.14.202",
-        "@types/node": "^17.0.45",
+        "@types/node": "^20.12.5",
         "@types/react": "^18.0.32",
         "@vdemedes/prettier-config": "^2.0.1",
         "auto-changelog": "^2.4.0",
@@ -57,19 +57,10 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "prettier": "^2.8.7",
         "ts-node": "^10.9.1",
-        "typescript": "^5.0.3"
+        "typescript": "^5.4.4"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "apps/ogre-cli/node_modules/@types/node": {
-      "version": "20.11.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
-      "integrity": "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "apps/ogre-cli/node_modules/@types/react": {
@@ -581,19 +572,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "apps/ogre-cli/node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "apps/ogre-cli/node_modules/write-file-atomic": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
@@ -630,8 +608,8 @@
     "apps/ogre-demo": {
       "version": "0.10.0",
       "dependencies": {
-        "@dotinc/ogre": "^0.9.0",
-        "@dotinc/ogre-react": "^0.9.0",
+        "@dotinc/ogre": "*",
+        "@dotinc/ogre-react": "*",
         "next": "12.1.0",
         "next-plausible": "^3.12.0",
         "next-transpile-modules": "^9.1.0",
@@ -641,13 +619,13 @@
         "react-live": "3.2.0"
       },
       "devDependencies": {
-        "@types/node": "17.0.45",
+        "@types/node": "^20.12.5",
         "@types/react": "17.0.39",
         "config": "^0.2.0",
         "eslint": "8.56.0",
         "eslint-config-next": "12.3.4",
         "tsconfig": "*",
-        "typescript": "4.7.4"
+        "typescript": "^5.4.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4070,10 +4048,13 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
     },
     "node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "dev": true
+      "version": "20.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.5.tgz",
+      "integrity": "sha512-BD+BjQ9LS/D8ST9p5uqBxghlN+S42iuNxjsUGjeZobe/ciXzk2qb1B6IXc6AnRLS+yFJRpN2IPEHMzwspfDJNw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -14024,15 +14005,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
+      "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-memoize": {
@@ -14826,13 +14807,13 @@
         "tslib": "^2.6.2"
       },
       "devDependencies": {
-        "@types/node": "^17.0.45",
+        "@types/node": "^20.12.5",
         "@types/uuid": "^8.3.4",
         "nyc": "^15.1.0",
         "tap": "^18.7.0",
         "ts-node": "^10.8.1",
         "tsx": "^4.7.1",
-        "typescript": "^4.7.4",
+        "typescript": "^5.4.4",
         "uuid": "^8.3.2"
       }
     },
@@ -14841,7 +14822,7 @@
       "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "@dotinc/ogre": "^0.9.0",
+        "@dotinc/ogre": "*",
         "@gitgraph/react": "^1.6.0"
       },
       "devDependencies": {
@@ -14849,7 +14830,7 @@
         "@types/react-dom": "^17.0.13",
         "config": "^0.2.0",
         "tsconfig": "^0.1.1",
-        "typescript": "^4.7.4"
+        "typescript": "^5.4.4"
       }
     },
     "packages/tsconfig": {
@@ -15451,7 +15432,7 @@
     "@dotinc/ogre": {
       "version": "file:packages/ogre",
       "requires": {
-        "@types/node": "^17.0.45",
+        "@types/node": "^20.12.5",
         "@types/uuid": "^8.3.4",
         "fast-json-patch": "^3.1.1",
         "fflate": "^0.8.2",
@@ -15461,7 +15442,7 @@
         "ts-node": "^10.8.1",
         "tslib": "^2.6.2",
         "tsx": "^4.7.1",
-        "typescript": "^4.7.4",
+        "typescript": "^5.4.4",
         "uuid": "^8.3.2"
       }
     },
@@ -15473,7 +15454,7 @@
         "@sindresorhus/tsconfig": "^3.0.1",
         "@types/color-convert": "^2.0.3",
         "@types/lodash": "^4.14.202",
-        "@types/node": "^17.0.45",
+        "@types/node": "^20.12.5",
         "@types/react": "^18.0.32",
         "@vdemedes/prettier-config": "^2.0.1",
         "auto-changelog": "^2.4.0",
@@ -15487,17 +15468,9 @@
         "meow": "^11.0.0",
         "prettier": "^2.8.7",
         "ts-node": "^10.9.1",
-        "typescript": "^5.0.3"
+        "typescript": "^5.4.4"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
-          "integrity": "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==",
-          "dev": true,
-          "requires": {
-            "undici-types": "~5.26.4"
-          }
-        },
         "@types/react": {
           "version": "18.2.55",
           "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.55.tgz",
@@ -15826,12 +15799,6 @@
           "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
           "integrity": "sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ=="
         },
-        "typescript": {
-          "version": "5.3.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-          "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-          "dev": true
-        },
         "write-file-atomic": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
@@ -15860,13 +15827,13 @@
     "@dotinc/ogre-react": {
       "version": "file:packages/ogre-react",
       "requires": {
-        "@dotinc/ogre": "^0.9.0",
+        "@dotinc/ogre": "*",
         "@gitgraph/react": "^1.6.0",
         "@types/react": "^17.0.39",
         "@types/react-dom": "^17.0.13",
         "config": "^0.2.0",
         "tsconfig": "^0.1.1",
-        "typescript": "^4.7.4"
+        "typescript": "^5.4.4"
       }
     },
     "@endemolshinegroup/cosmiconfig-typescript-loader": {
@@ -17636,10 +17603,13 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
     },
     "@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "dev": true
+      "version": "20.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.5.tgz",
+      "integrity": "sha512-BD+BjQ9LS/D8ST9p5uqBxghlN+S42iuNxjsUGjeZobe/ciXzk2qb1B6IXc6AnRLS+yFJRpN2IPEHMzwspfDJNw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -22424,9 +22394,9 @@
     "ogre-demo": {
       "version": "file:apps/ogre-demo",
       "requires": {
-        "@dotinc/ogre": "^0.9.0",
-        "@dotinc/ogre-react": "^0.9.0",
-        "@types/node": "17.0.45",
+        "@dotinc/ogre": "*",
+        "@dotinc/ogre-react": "*",
+        "@types/node": "^20.12.5",
         "@types/react": "17.0.39",
         "config": "^0.2.0",
         "eslint": "8.56.0",
@@ -22439,7 +22409,7 @@
         "react-dom": "17.0.2",
         "react-live": "3.2.0",
         "tsconfig": "*",
-        "typescript": "4.7.4"
+        "typescript": "^5.4.4"
       }
     },
     "once": {
@@ -24863,9 +24833,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
+      "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw=="
     },
     "typescript-memoize": {
       "version": "1.1.0",

--- a/packages/ogre-react/OgreGraph.tsx
+++ b/packages/ogre-react/OgreGraph.tsx
@@ -1,24 +1,57 @@
 import React, { useEffect, useState } from "react";
 
 import { formatGit2Json, RepositoryObject } from "@dotinc/ogre";
-import { Gitgraph } from "@gitgraph/react";
-import { GitgraphOptions } from "@gitgraph/core/src/gitgraph";
+import {
+  type CommitOptions,
+  Gitgraph,
+  type TemplateName,
+  type Orientation,
+  type Mode,
+} from "@gitgraph/react";
+import type { Template } from "@gitgraph/core/lib/template";
+
+export {
+  templateExtend,
+  metroTemplate,
+  blackArrowTemplate,
+} from "@gitgraph/core/lib/template";
+
+interface GitgraphOptions {
+  template?: TemplateName | Template;
+  orientation?: Orientation;
+  reverseArrow?: boolean;
+  initCommitOffsetX?: number;
+  initCommitOffsetY?: number;
+  mode?: Mode;
+  author?: string;
+  branchLabelOnEveryCommit?: boolean;
+  commitMessage?: string;
+}
 
 export interface OgreGraphProps {
   repository: RepositoryObject<any>;
-  options: GitgraphOptions | undefined;
+  options?: GitgraphOptions;
+  commitOptions?: Map<string, CommitOptions>;
 }
 
 export const OgreGraph: React.FC<OgreGraphProps> = ({
   repository,
   options,
+  commitOptions,
 }) => {
   const [graphData, setGraphData] = useState<any[] | undefined>(undefined);
 
   useEffect(() => {
     if (!graphData) {
       const history = repository.getHistory();
-      setGraphData(formatGit2Json(history));
+      const data = formatGit2Json(history).map((c) => {
+        const opts = commitOptions?.get(c.hash);
+        return {
+          ...c,
+          ...(opts ? opts : {}),
+        };
+      });
+      setGraphData(data);
     }
   }, [repository]);
 

--- a/packages/ogre-react/OgreGraph.tsx
+++ b/packages/ogre-react/OgreGraph.tsx
@@ -2,12 +2,17 @@ import React, { useEffect, useState } from "react";
 
 import { formatGit2Json, RepositoryObject } from "@dotinc/ogre";
 import { Gitgraph } from "@gitgraph/react";
+import { GitgraphOptions } from "@gitgraph/core/src/gitgraph";
 
 export interface OgreGraphProps {
   repository: RepositoryObject<any>;
+  options: GitgraphOptions | undefined;
 }
 
-export const OgreGraph: React.FC<OgreGraphProps> = ({ repository }) => {
+export const OgreGraph: React.FC<OgreGraphProps> = ({
+  repository,
+  options,
+}) => {
   const [graphData, setGraphData] = useState<any[] | undefined>(undefined);
 
   useEffect(() => {
@@ -18,7 +23,7 @@ export const OgreGraph: React.FC<OgreGraphProps> = ({ repository }) => {
   }, [repository]);
 
   return !graphData ? null : (
-    <Gitgraph>
+    <Gitgraph options={options}>
       {(gitgraph) => {
         gitgraph.import(graphData);
       }}

--- a/packages/ogre-react/package.json
+++ b/packages/ogre-react/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/dotindustries/ogre.git"
   },
   "dependencies": {
-    "@dotinc/ogre": "^0.9.0",
+    "@dotinc/ogre": "*",
     "@gitgraph/react": "^1.6.0"
   },
   "devDependencies": {
@@ -17,7 +17,7 @@
     "@types/react-dom": "^17.0.13",
     "config": "^0.2.0",
     "tsconfig": "^0.1.1",
-    "typescript": "^4.7.4"
+    "typescript": "^5.4.4"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/ogre-react/tsconfig.json
+++ b/packages/ogre-react/tsconfig.json
@@ -1,7 +1,13 @@
 {
   "extends": "tsconfig/react-library.json",
-  "include": ["."],
-  "exclude": ["dist", "build", "node_modules"],
+  "include": [
+    "."
+  ],
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules"
+  ],
   "compilerOptions": {
     "downlevelIteration": true
   }

--- a/packages/ogre/package.json
+++ b/packages/ogre/package.json
@@ -26,13 +26,13 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@types/node": "^17.0.45",
+    "@types/node": "^20.12.5",
     "@types/uuid": "^8.3.4",
     "nyc": "^15.1.0",
     "tap": "^18.7.0",
     "ts-node": "^10.8.1",
     "tsx": "^4.7.1",
-    "typescript": "^4.7.4",
+    "typescript": "^5.4.4",
     "uuid": "^8.3.2"
   },
   "publishConfig": {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @dotinc/ogre@0.10.0-canary.173.8587699031.0
  npm install @dotinc/ogre-react@0.10.0-canary.173.8587699031.0
  # or 
  yarn add @dotinc/ogre@0.10.0-canary.173.8587699031.0
  yarn add @dotinc/ogre-react@0.10.0-canary.173.8587699031.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
