### PR TITLE
feat: temporal support

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,5 +18,5 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true # optional (default = false)
-          verbose: true # optional (default = false)
+#          fail_ci_if_error: true # optional (default = false)
+#          verbose: true # optional (default = false)


### PR DESCRIPTION
feat: allow override of hash algo for temporal support

chore: remove ci fail if codecov bails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to customize commit hash calculation in the `Repository` class with an optional `calculateCommitHashFn` function.

- **Refactor**
  - Updated import statements to use TypeScript type imports for better type management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @dotinc/ogre@0.11.0-canary.186.9603106672.0
  npm install @dotinc/ogre-react@0.11.0-canary.186.9603106672.0
  # or 
  yarn add @dotinc/ogre@0.11.0-canary.186.9603106672.0
  yarn add @dotinc/ogre-react@0.11.0-canary.186.9603106672.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
